### PR TITLE
Custom request hostname and response fragment sizes

### DIFF
--- a/jni/iodine-client.c
+++ b/jni/iodine-client.c
@@ -85,7 +85,7 @@ JNIEXPORT jint JNICALL Java_org_xapek_andiodine_IodineClient_getDnsFd(
 
 JNIEXPORT jint JNICALL Java_org_xapek_andiodine_IodineClient_connect(
 		JNIEnv *env, jclass klass, jstring j_nameserv_addr, jstring j_topdomain, jboolean j_raw_mode, jboolean j_lazy_mode,
-		jstring j_password) {
+		jstring j_password, jint j_request_hostname_size, jint j_response_fragment_size) {
 
 	// XXX strdup leaks
 	const char *__p_nameserv_addr = (*env)->GetStringUTFChars(env,
@@ -109,14 +109,14 @@ JNIEXPORT jint JNICALL Java_org_xapek_andiodine_IodineClient_connect(
 	strncpy(passwordField, p_password, 32);
 	(*env)->ReleaseStringUTFChars(env, j_password, p_password);
 
-    tun_config_android.request_disconnect = 0;
+	tun_config_android.request_disconnect = 0;
 
 	int selecttimeout = 2; // original: 4
 	int lazy_mode;
-	int hostname_maxlen = 0xFF;
+	int hostname_maxlen = j_request_hostname_size;
 	int raw_mode;
-	int autodetect_frag_size = 1;
-	int max_downstream_frag_size = 3072;
+	int autodetect_frag_size = j_response_fragment_size == 0 ? 1 : 0;
+	int max_downstream_frag_size = j_response_fragment_size;
 
 	if (j_raw_mode) {
 		raw_mode = 1;

--- a/src/main/java/org/xapek/andiodine/IodineClient.java
+++ b/src/main/java/org/xapek/andiodine/IodineClient.java
@@ -9,7 +9,7 @@ public class IodineClient {
     public static native int getDnsFd();
 
     public static native int connect(String nameserv_addr, String topdomain, boolean raw_mode, boolean lazy_mode,
-                                     String password);
+                                     String password, int request_hostname_size, int response_fragment_size);
 
     public static native String getIp();
 

--- a/src/main/java/org/xapek/andiodine/IodinePref.java
+++ b/src/main/java/org/xapek/andiodine/IodinePref.java
@@ -73,6 +73,11 @@ public class IodinePref extends org.xapek.andiodine.preferences.PreferenceActivi
         addPreference(ConfigDatabase.COLUMN_CONF_RAW_MODE, "Raw Mode", R.string.pref_help_raw, false);
         // Default Route
         addPreference(ConfigDatabase.COLUMN_CONF_DEFAULT_ROUTE, "Default Route", R.string.pref_help_default_route, true);
+
+        addPreference(ConfigDatabase.COLUMN_CONF_REQUEST_HOSTNAME_SIZE,
+            "Request Hostname Size", R.string.pref_request_hostname_size, "255");
+        addPreference(ConfigDatabase.COLUMN_CONF_RESPONSE_FRAGMENT_SIZE,
+            "Response Fragment Size", R.string.pref_response_fragment_size, "0");
     }
 
     @Override

--- a/src/main/java/org/xapek/andiodine/IodineVpnService.java
+++ b/src/main/java/org/xapek/andiodine/IodineVpnService.java
@@ -219,7 +219,8 @@ public class IodineVpnService extends VpnService implements Runnable {
             }
 
             int ret = IodineClient.connect(tunnelNamesver, mConfiguration.getTopDomain(), mConfiguration.getRawMode(),
-                    mConfiguration.getLazyMode(), password);
+                    mConfiguration.getLazyMode(), password, mConfiguration.getRequestHostnameSize(),
+                    mConfiguration.getResponseFragmentSize());
 
             String errorMessage = "";
             switch (ret) {

--- a/src/main/java/org/xapek/andiodine/config/ConfigDatabase.java
+++ b/src/main/java/org/xapek/andiodine/config/ConfigDatabase.java
@@ -30,6 +30,8 @@ public class ConfigDatabase extends SQLiteOpenHelper {
     static public final String COLUMN_CONF_LAZY_MODE = "lazy_mode";
     static public final String COLUMN_CONF_DEFAULT_ROUTE = "default_route";
     static public final String COLUMN_CONF_REQUEST_TYPE = "request_type";
+    static public final String COLUMN_CONF_REQUEST_HOSTNAME_SIZE = "request_hostname_size";
+    static public final String COLUMN_CONF_RESPONSE_FRAGMENT_SIZE = "response_fragment_size";
 
     private static final String createStmt = "CREATE TABLE " + TABLE_NAME_CONF + " (" + //
             COLUMN_CONF_ID + " INTEGER PRIMARY KEY," + //
@@ -43,7 +45,9 @@ public class ConfigDatabase extends SQLiteOpenHelper {
             COLUMN_CONF_RAW_MODE + " INTEGER," + // Boolean stored as 1=true / 0=false
             COLUMN_CONF_LAZY_MODE + " INTEGER," + //
             COLUMN_CONF_DEFAULT_ROUTE + " INTEGER," + //
-            COLUMN_CONF_REQUEST_TYPE + " TEXT" + //
+            COLUMN_CONF_REQUEST_TYPE + " TEXT," + //
+            COLUMN_CONF_REQUEST_HOSTNAME_SIZE + " INTEGER," + //
+            COLUMN_CONF_RESPONSE_FRAGMENT_SIZE + " INTEGER" + //
             ");";
 
     public ConfigDatabase(Context context) {

--- a/src/main/java/org/xapek/andiodine/config/IodineConfiguration.java
+++ b/src/main/java/org/xapek/andiodine/config/IodineConfiguration.java
@@ -125,6 +125,22 @@ public class IodineConfiguration {
 		return v;
 	}
 
+	public int getRequestHostnameSize() {
+		return v.getAsInteger(ConfigDatabase.COLUMN_CONF_REQUEST_HOSTNAME_SIZE);
+	}
+
+	public void setRequestHostnameSize(int requestHostnameFragmentSize) {
+		v.put(ConfigDatabase.COLUMN_CONF_REQUEST_HOSTNAME_SIZE, requestHostnameFragmentSize);
+	}
+
+	public int getResponseFragmentSize() {
+		return v.getAsInteger(ConfigDatabase.COLUMN_CONF_RESPONSE_FRAGMENT_SIZE);
+	}
+
+	public void setResponseFragmentSize(int responseFragmentSize) {
+		v.put(ConfigDatabase.COLUMN_CONF_RESPONSE_FRAGMENT_SIZE, responseFragmentSize);
+	}
+
 	@Override
 	public String toString() {
 		return "[IodineConfiguration name=" + getName() + "]";

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -39,6 +39,8 @@
     <string name="pref_help_nameserver">IP-Adresse eine speziellen Nameserver der gesetzt werden soll wenn Nameserver Modus = Custom ist.</string>
     <string name="pref_help_request_type">Typ der DNS Abfragen. Standardmäßig wird die beste Request type automatisch ausgewählt.</string>
     <string name="pref_help_default_route">Legt fest ob die Default Route gesetzt wird nachdem die Verbindung aufgebaut wurde</string>
+    <string name="pref_request_hostname_size">Maximale Größe des Upstream-Hostnamen. Die zulässigen Werte liegen zwischen 100 und 255. Der Standardwert ist 255. verkleinern, wenn Sie finden, einige DNS-Relais beantworten, um in voller Länge Anfragen unzuverlässig geben sehr unterschiedlichen Ergebnisse der Fragmentgröße autoprobe.</string>
+    <string name="pref_response_fragment_size">Antwort Fragmentgröße. Autoprobing, wenn auf 0 gesetzt, die ein Standardwert ist.</string>
     <string name="enable">Aktivieren</string>
     <string name="vpnservice_error_configuration_incomplete">Konfiguration ist unvollständig</string>
     <string name="vpnservice_error_already_running">Kann das VPN nicht starten, es läuft bereits.</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -60,6 +60,12 @@
         (returning CNAME). Note that SRV, MX and A may/will cause additional lookups by "smart" caching nameservers to
         get an actual IP address, which may either slow down or fail completely.
     </string>
+    <string name="pref_request_hostname_size">Maximum size of upstream hostnames. Valid values are from 100 to 255.
+        Default is 255. Decrease if you find some DNS relays answer to full-length queries unreliably giving widely
+        varying results of fragment size autoprobe.
+    </string>
+    <string name="pref_response_fragment_size">Response fragment size. Autoprobed when set to 0 which is a default.
+    </string>
     <string name="enable">Enable</string>
     <string name="vpnservice_error_configuration_incomplete">Configuration is incomplete</string>
     <string name="vpnservice_error_already_running">Cannot start VPN Service, VPN-Thread is already running</string>


### PR DESCRIPTION
I have noticed that sometimes fragment size discovery does not discover the optimal value. This PR adds an ability to specify a fixed response fragment size.

Also added an ability to change request hostname size. According to `Iodine` documentation, decreasing this value makes fragment size discovery more reliable in some cases.

Please note that all strings are translated to German language using Google Translate, so it may not be of the best quality.