### PR TITLE
Try querying all net.dns* properties to determine nameserver to use

### DIFF
--- a/jni/iodine-client.c
+++ b/jni/iodine-client.c
@@ -210,15 +210,15 @@ JNIEXPORT jint JNICALL Java_org_xapek_andiodine_IodineClient_getMtu(JNIEnv *env,
 // String IodineClient.getPropertyNetDns1
 JNIEXPORT jstring JNICALL Java_org_xapek_andiodine_IodineClient_getPropertyNetDns1(
 		JNIEnv *env, jclass klass) {
-    struct sockaddr_in sa;
+	struct sockaddr_in sa;
 	for (int i = 1; i <= MAX_DNS_PROPERTIES; i++) {
-        char prop_name[PROP_NAME_MAX];
-        char dns[PROP_VALUE_MAX];
-        snprintf(prop_name, sizeof(prop_name), "net.dns%d", i);
-        __system_property_get(prop_name, dns);
-        if (inet_pton(AF_INET, dns, &(sa.sin_addr)) == 1) {
-            return (*env)->NewStringUTF(env, dns);
-        }
-    }
+		char prop_name[PROP_NAME_MAX];
+		char dns[PROP_VALUE_MAX];
+		snprintf(prop_name, sizeof(prop_name), "net.dns%d", i);
+		__system_property_get(prop_name, dns);
+		if (inet_pton(AF_INET, dns, &(sa.sin_addr)) == 1) {
+			return (*env)->NewStringUTF(env, dns);
+		}
+	}
 	return (*env)->NewStringUTF(env, "");
 }

--- a/src/main/java/org/xapek/andiodine/IodineVpnService.java
+++ b/src/main/java/org/xapek/andiodine/IodineVpnService.java
@@ -209,21 +209,21 @@ public class IodineVpnService extends VpnService implements Runnable {
             Log.d(TAG, "VPN Thread enter");
             setStatus(ACTION_STATUS_CONNECT, mConfiguration.getId(), null);
 
-            String tunnelNamesver = IodineClient.getPropertyNetDns1();
-            if (tunnelNamesver == "") {
+            String tunnelNameserver = IodineClient.getPropertyNetDns1();
+            if (tunnelNameserver == "") {
                 Log.e(TAG, "No valid IPv4 name servers detected. Aborting...");
                 return;
             }
-            Log.d(TAG, "using name server: " + tunnelNamesver);
+            Log.d(TAG, "using name server: " + tunnelNameserver);
             if (!"".equals(mConfiguration.getTunnelNameserver())) {
-                tunnelNamesver = mConfiguration.getTunnelNameserver();
+                tunnelNameserver = mConfiguration.getTunnelNameserver();
             }
             String password = "";
             if (!"".equals(mConfiguration.getPassword())) {
                 password = mConfiguration.getPassword();
             }
 
-            int ret = IodineClient.connect(tunnelNamesver, mConfiguration.getTopDomain(), mConfiguration.getRawMode(),
+            int ret = IodineClient.connect(tunnelNameserver, mConfiguration.getTopDomain(), mConfiguration.getRawMode(),
                     mConfiguration.getLazyMode(), password, mConfiguration.getRequestHostnameSize(),
                     mConfiguration.getResponseFragmentSize());
 

--- a/src/main/java/org/xapek/andiodine/IodineVpnService.java
+++ b/src/main/java/org/xapek/andiodine/IodineVpnService.java
@@ -210,7 +210,7 @@ public class IodineVpnService extends VpnService implements Runnable {
             setStatus(ACTION_STATUS_CONNECT, mConfiguration.getId(), null);
 
             String tunnelNameserver = IodineClient.getPropertyNetDns1();
-            if (tunnelNameserver == "") {
+            if (tunnelNameserver.isEmpty()) {
                 Log.e(TAG, "No valid IPv4 name servers detected. Aborting...");
                 return;
             }

--- a/src/main/java/org/xapek/andiodine/IodineVpnService.java
+++ b/src/main/java/org/xapek/andiodine/IodineVpnService.java
@@ -210,6 +210,11 @@ public class IodineVpnService extends VpnService implements Runnable {
             setStatus(ACTION_STATUS_CONNECT, mConfiguration.getId(), null);
 
             String tunnelNamesver = IodineClient.getPropertyNetDns1();
+            if (tunnelNamesver == "") {
+                Log.e(TAG, "No valid IPv4 name servers detected. Aborting...");
+                return;
+            }
+            Log.d(TAG, "using name server: " + tunnelNamesver);
             if (!"".equals(mConfiguration.getTunnelNameserver())) {
                 tunnelNamesver = mConfiguration.getTunnelNameserver();
             }


### PR DESCRIPTION
The problem was that net.dns1 was set as an ipv6 address and as a consequence andiodine failed to connect. `errno` was being set to "Invalid Argument" when calling sendto on the socket. At least for me net.dns2 was an ipv4 address.