### PR TITLE
Fix a double header definition on newer NDK versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ jdk:
 
 android:
   components:
-    - build-tools-21.1.2
-    - android-15
+    - build-tools-25.0.2
+    - android-21
 
 before_install:
 - git clone --depth 1 https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -12,7 +12,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    buildToolsVersion '25.0.2'
 
     sourceSets.main {
         jniLibs.srcDir 'libs'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 21 21:42:02 GMT 2016
+#Fri Oct 13 18:56:29 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/jni/iodine/src/android_dns.h
+++ b/jni/iodine/src/android_dns.h
@@ -1,6 +1,8 @@
 
 #ifndef __FIX_ANDROID_H__
 #define __FIX_ANDROID_H__
+#include <arpa/nameser.h>
+#ifndef _ARPA_NAMESER_COMPAT_
 
 typedef struct {
 	unsigned id :16;
@@ -36,4 +38,5 @@ typedef struct {
 #define T_TXT		16
 #define T_SRV		33
 
-#endif
+#endif //_ARPA_NAMESER_COMPAT_
+#endif //__FIX_ANDROID_H__


### PR DESCRIPTION
Newer Android NDK versions (>21) have  APRA Nameser_compat.h, which causes a double struct definition. This patch checks if APRA nameser.h includes APRA nameser_compat.h and if that is the case, it disables android_dns.h. 

I don't really know how to install a old version of a NDK, so I can't 100% verify that I didn't break anything, but it should be fine. 